### PR TITLE
Document environment setup and refresh tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ These instructions apply to the entire repository unless a nested `AGENTS.md` ov
 ## Documentation expectations
 - Update `README.md` and `docs/Wiki.md` whenever you introduce, rename, or remove features, scripts, or conventions.
 - When you add workflow explanations longer than a few paragraphs, place them under `docs/wiki/` and cross-link from the README.
+- Keep `.env.example` files (frontend and backend) in sync with the variables consumed by the codebase and document the usage in the README when they change.
 
 ## Frontend workflow (`frontend/`)
 - Prefer composing UI inside feature modules and keep `src/App.tsx` focused on orchestration/layout.

--- a/README.md
+++ b/README.md
@@ -40,14 +40,36 @@ Nodipar/
 ```
 
 ## 🚀 Getting started
-```bash
-cd frontend
-npm install
-npm run dev
-```
-The development server runs at `http://localhost:5173`. For production validation, run `npm run build`.
+1. **Install dependencies**
+   ```bash
+   cd frontend && npm install
+   cd ../backend && npm install
+   ```
+2. **Copy the environment templates**
+   ```bash
+   cp frontend/.env.example frontend/.env
+   cp backend/.env.example backend/.env
+   ```
+3. **Run the frontend**
+   ```bash
+   cd frontend
+   npm run dev
+   ```
+   The Vite dev server runs at `http://localhost:5173`.
 
-## 🛠 Backend API
+## 🧩 Environment configuration
+- **Where do `.env` files live?**
+  - Frontend variables belong in `frontend/.env` (Vite exposes them with the `VITE_` prefix).
+  - Backend variables belong in `backend/.env` and are read via `backend/src/config/env.ts`.
+- **Frontend variables** (see `frontend/.env.example`)
+  - `VITE_API_BASE_URL` — URL that the SPA uses for API calls (defaults to `http://localhost:4000`).
+  - `VITE_ENABLE_MOCK_DATA` — toggle to keep mock overlays available while the API matures.
+- **Backend variables** (see `backend/.env.example`)
+  - `PORT` — HTTP port for the Express server.
+  - `DATABASE_URL` — Prisma connection string (SQLite by default).
+  - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM_EMAIL` — outbound mail credentials consumed by Nodipar's notification helpers.
+
+## 🛠 Backend API & database
 The backend lives in `backend/` and exposes feature-aligned REST endpoints that mirror the fourteen Nodipar pillars.
 
 ```bash
@@ -60,14 +82,34 @@ npm run dev
 ```
 
 - The API boots on `http://localhost:4000` by default (configurable through `.env`).
+- Nodipar uses a local SQLite database stored in `backend/prisma/dev.db`. Update `DATABASE_URL` if you prefer PostgreSQL or another provider.
 - `prisma/schema.prisma` models posts, events, chats, media, polls, notifications, resources, gamification, and moderation queues.
+- Run `npx prisma migrate dev` whenever you touch `prisma/schema.prisma` so the SQLite file stays in sync, and `npm run build` before deployment to type-check the project.
 - Each route group resides under `src/modules/<feature>/`—for example:
   - `/posts` handles the Adda Wall (posts, comments, reactions, pinning).
   - `/events` powers the Events Center (RSVPs, discussion threads, polls).
   - `/chats` covers BondhoChat (direct messages, event auto-chats, reactions).
   - `/gallery` serves media albums, Memory of the Week, and tagging.
   - `/gamification`, `/notifications`, `/resources`, `/birthdays`, `/moderation`, and `/engagement` map directly to their feature pillars.
-- Run `npm run build` to produce the production bundle and ensure TypeScript safety before deployment.
+
+## ✉️ SMTP setup
+1. Choose a provider (Mailtrap, Postmark, SES, Gmail App Password, etc.).
+2. Populate the SMTP fields inside `backend/.env` using the provider's credentials.
+3. If you are using Gmail, create an App Password and set `SMTP_PORT=587` with `SMTP_HOST=smtp.gmail.com`.
+4. Restart the backend (or `docker compose up`) so `backend/src/config/env.ts` picks up the new credentials.
+
+## 🐳 Running with Docker Compose
+Docker Compose can spin up both workspaces once you have copied the `.env` files.
+
+```bash
+cp frontend/.env.example frontend/.env
+cp backend/.env.example backend/.env
+docker compose up --build
+```
+
+- The frontend is available at `http://localhost:5173` and will call the backend using `VITE_API_BASE_URL` when the data layer is wired up.
+- The backend listens on `http://localhost:4000`; migrations and Prisma client generation run automatically at container start.
+- Stop the stack with `docker compose down` and rebuild after schema changes so the generated Prisma client stays in sync.
 
 ## 🧭 Feature line-up
 | Area | What it covers |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,8 @@
 # Nodipar backend environment variables
 PORT=4000
 DATABASE_URL="file:./dev.db"
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USERNAME=your-smtp-username
+SMTP_PASSWORD=your-smtp-password
+SMTP_FROM_EMAIL=notifications@example.com

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -19,3 +19,4 @@ These instructions apply to all files within the `backend/` directory.
 ## Documentation
 - Document new endpoints and data contracts inside `docs/Wiki.md` under a new dated entry.
 - Update `README.md` when backend commands, environment variables, or deployment notes change.
+- Whenever you introduce infrastructure knobs (database URLs, SMTP providers, etc.), reflect them in `backend/.env.example` and the environment helper (`src/config/env.ts`).

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -12,4 +12,11 @@ export const env = {
   nodeEnv: process.env.NODE_ENV ?? 'development',
   port: parseNumber(process.env.PORT, 4000),
   databaseUrl: process.env.DATABASE_URL ?? 'file:./dev.db',
+  smtp: {
+    host: process.env.SMTP_HOST ?? '',
+    port: parseNumber(process.env.SMTP_PORT, 587),
+    username: process.env.SMTP_USERNAME ?? '',
+    password: process.env.SMTP_PASSWORD ?? '',
+    fromEmail: process.env.SMTP_FROM_EMAIL ?? '',
+  },
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,27 @@
 services:
   backend:
-    build: ./backend
+    image: node:18-alpine
+    working_dir: /app
     env_file:
       - ./backend/.env
+    command: >-
+      sh -c "npm install && npx prisma generate && npx prisma migrate deploy && npm run dev"
     ports:
-      - "5000:5000"
+      - "4000:4000"
     volumes:
       - ./backend:/app
     restart: unless-stopped
   frontend:
-    build: ./frontend
+    image: node:18-alpine
+    working_dir: /app
     env_file:
       - ./frontend/.env
+    command: >-
+      sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
     ports:
-      - "3000:5173"
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+    depends_on:
+      - backend
     restart: unless-stopped

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -19,3 +19,9 @@
 ## Contributing forward
 - Add new features by extending `frontend/src/features/<feature-name>/` and wiring them into `AppShell`.
 - Update this wiki entry with each significant UI or architectural enhancement.
+
+## 2024-10-12 — Environment & ops tooling
+- Documented environment variable locations and SMTP expectations in the root README.
+- Added `.env.example` templates for both the frontend (`VITE_API_BASE_URL`, `VITE_ENABLE_MOCK_DATA`) and backend (SMTP credentials).
+- Extended the backend `env` helper to surface SMTP settings to the application layer.
+- Refreshed `docker-compose.yml` to launch Node-based dev containers that generate the Prisma client and run migrations on boot.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+# Nodipar frontend environment variables
+# Point the web app to the backend API gateway.
+VITE_API_BASE_URL=http://localhost:4000
+
+# Toggle mock data overlays ("true" or "false").
+VITE_ENABLE_MOCK_DATA=true

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -17,3 +17,4 @@ These instructions apply to all files within the `frontend/` directory.
 
 ## Documentation
 - When introducing a new feature module, document it briefly in `docs/Wiki.md` and mention any data mocks you add under `src/data/`.
+- Keep `frontend/.env.example` aligned with any configuration you reference via `import.meta.env`.


### PR DESCRIPTION
## Summary
- document the exact environment files and variables the frontend and backend expect, including SMTP credentials, and answer common setup questions in the README
- add `.env.example` templates for both workspaces and expose SMTP configuration through the backend environment helper
- refresh docker-compose so it can boot the app stack with Node images while generating Prisma clients and running migrations automatically

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cb6ed15a908333b2f2ffbd0e494ed7